### PR TITLE
design 버튼 컴포넌트

### DIFF
--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,0 +1,17 @@
+import React, { ButtonHTMLAttributes } from "react";
+import StyledButton from "./button.style";
+
+interface CommonComponentProps {
+  children?: React.ReactNode;
+  customStyle?: React.CSSProperties;
+}
+
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    CommonComponentProps {}
+
+const Button = ({ children, ...atr }: ButtonProps) => {
+  return <StyledButton {...atr}>{children}</StyledButton>;
+};
+
+export default Button;

--- a/src/components/common/button/button.style.ts
+++ b/src/components/common/button/button.style.ts
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+const StyledButton = styled.button`
+  margin: 5px;
+  padding: 5px;
+  border: none;
+  border-radius: 6px;
+  font-size: 20px;
+  color: #fff;
+  background-color: #6a24fe;
+  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+
+  &[type="submit"] {
+    width: 100%;
+    height: 48px;
+    font-size: 16px;
+  }
+
+  :disabled {
+    cursor: not-allowed;
+    background-color: grey;
+  }
+
+  :hover:not(:disabled) {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25), 0 4px 8px rgba(0, 0, 0, 0.25);
+  }
+`;
+
+export default StyledButton;


### PR DESCRIPTION
* 중복 CSS 제거
* &[type=submit]에서 props를 이용해 버튼 비활성화 여부에 따라 스타일 하던 것을, :disabled에서 한 번에 관리하도록 변경

* 사용자 경험 향상을 위해, 버튼 비활성화 경우를 제외하고 호버시 밑에 그림자가 생기도록 함.