### PR TITLE
feat: axios instance에서 에러처리 토큰삭제 추가

### DIFF
--- a/src/api/AuthApi.ts
+++ b/src/api/AuthApi.ts
@@ -7,21 +7,11 @@ const { SIGNUP_SUCCESS, SIGNUP_ERROR, SIGNIN_ERROR, SIGNIN_SUCCESS } = CONSTANT;
 const AuthApi = () => {
   const signIn = async (formData: SigninParam): Promise<SigninResponse> => {
     const result = await customAxios.post("/auth/signin", formData);
-    if (result.status === 201) {
-      alert(SIGNIN_SUCCESS);
-    } else {
-      alert(SIGNIN_ERROR);
-    }
     return result.data;
   };
 
   const signUp = async (formData: SignupParam): Promise<void> => {
     const result = await customAxios.post("/auth/signup", formData);
-    if (result.status === 200) {
-      alert(SIGNUP_SUCCESS);
-    } else {
-      alert(SIGNUP_ERROR);
-    }
     return result.data;
   };
 

--- a/src/lib/customAxios.ts
+++ b/src/lib/customAxios.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 import constant from "../constant/constant.json";
+import { TOKEN_KEY } from "../constant/constant";
+import { getToken, removeToken } from "../utils/token";
 
 const customAxios = axios.create({
   baseURL: constant.SERVER,
@@ -7,13 +9,14 @@ const customAxios = axios.create({
 
 customAxios.interceptors.request.use(
   config => {
-    const token = localStorage.getItem("access_token");
+    const token = getToken(TOKEN_KEY)
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   },
   error => {
+    removeToken(TOKEN_KEY);
     return Promise.reject(error);
   }
 );


### PR DESCRIPTION
우재님께서 말씀하신 customAxios에서 error 부분에 로컬스토리지의 token key값 삭제 추가.
constant 폴더의 constant.ts에 들어있는 TOKEN_KEY값으로 인자 전달
utills 폴더의 token 관련 함수들 사용